### PR TITLE
add window sensor accessory 6222/1 AP-64-WL

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ BuschJaegerApPlatform.prototype.getAccessoryClass = function (deviceId, channel,
         case '12':
             return ['BuschJaegerDimmAktorAccessory', null];
         case 'f':
+        case '64':
             return ['BuschJaegerContactSensorAccessory', null];
         case '23':
             return ['BuschJaegerThermostatAccessory', null];


### PR DESCRIPTION
Hi, I have customized the index.js to support the BJ window sensors 6222/1 AP-64-WL.