### PR TITLE
change contact sensor datapoint selection

### DIFF
--- a/dist/accessories/BuschJaegerContactSensorAccessory.js
+++ b/dist/accessories/BuschJaegerContactSensorAccessory.js
@@ -9,7 +9,16 @@ class BuschJaegerContactSensorAccessory extends BuschJaegerAccessory {
         this.services.contact = contactService;
     }
     getContactSensorState(callback) {
-        let detected = parseInt(this.getValue(this.channel, 'odp0000')) == 1 ? this.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED : this.Characteristic.ContactSensorState.CONTACT_DETECTED;
+        //find the correct contact sensor output datapoint
+        let outputDatapoints = this.platform.actuatorInfo[this.serial]['channels']['ch' + this.channel]['outputs']
+        let contactSensorODP = 'odp0000'
+        for (const outputDatapoint in outputDatapoints){
+            if(outputDatapoints[outputDatapoint]['pairingID'] === 53){
+                contactSensorODP = outputDatapoint.toString()
+                break;
+            }
+        }
+        let detected = parseInt(this.getValue(this.channel, contactSensorODP)) == 1 ? this.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED : this.Characteristic.ContactSensorState.CONTACT_DETECTED;
         callback(null, detected);
     }
     updateCharacteristics() {

--- a/src/accessories/BuschJaegerContactSensorAccessory.js
+++ b/src/accessories/BuschJaegerContactSensorAccessory.js
@@ -15,9 +15,17 @@ class BuschJaegerContactSensorAccessory extends BuschJaegerAccessory {
     }
 
     getContactSensorState(callback) {
-        let detected = parseInt(this.getValue(this.channel, 'odp0000')) == 1 ? this.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED : this.Characteristic.ContactSensorState.CONTACT_DETECTED
-
-        callback(null, detected)
+        //find the correct contact sensor output datapoint
+        let outputDatapoints = this.platform.actuatorInfo[this.serial]['channels']['ch' + this.channel]['outputs']
+        let contactSensorODP = 'odp0000'
+        for (const outputDatapoint in outputDatapoints){
+            if(outputDatapoints[outputDatapoint]['pairingID'] === 53){
+                contactSensorODP = outputDatapoint.toString()
+                break;
+            }
+        }
+        let detected = parseInt(this.getValue(this.channel, contactSensorODP)) == 1 ? this.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED : this.Characteristic.ContactSensorState.CONTACT_DETECTED;
+        callback(null, detected);
     }
 
     updateCharacteristics() {


### PR DESCRIPTION
# Description
Window contact sensors, which are connected via a Sensor/Schaltaktor 8/8-fach 6251/8.8, do not have the window status on the datapoint odp0000 but on the datapoint odp000c. This commit modifies the datapoint selection for the "BuschJaegerContactSensorAccessory". Now the pairingID 53 is searched and the corresponding datapoint is assigned.

# API sample for Sensor/Schaltaktor 8/8-fach 6251/8.8

Here is an API sample (shortened). The front door lock is open. Only the value odp000c changes here.

```
{
  "00000000-0000-0000-0000-000000000000": {
    "devices": {
      "XXXXXXXXXX": {
        "interface": "TP",
        "displayName": "Sensor/switch actuator, 8/8gang, MDRC",
        "unresponsive": false,
        "channels": {
          "ch0001": {
            "floor": "01",
            "room": "04",
            "displayName": "Haustür Schloss",
            "functionID": "f",
            "inputs": {
              "idp0000": {
                "pairingID": 256,
                "value": "0"
              },
              "idp0001": {
                "pairingID": 272,
                "value": "0"
              },
              "idp0002": {
                "pairingID": 288,
                "value": "0"
              },
              "idp0003": {
                "pairingID": 257,
                "value": "0"
              }
            },
            "outputs": {
              "odp0000": {
                "pairingID": 1,
                "value": "0"
              },
              "odp0001": {
                "pairingID": 16,
                "value": "0"
              },
              "odp0002": {
                "pairingID": 32,
                "value": "0"
              },
              "odp0003": {
                "pairingID": 33,
                "value": "0"
              },
              "odp0004": {
                "pairingID": 2,
                "value": "0"
              },
              "odp0005": {
                "pairingID": 3,
                "value": "0"
              },
              "odp0006": {
                "pairingID": 40,
                "value": "0"
              },
              "odp0007": {
                "pairingID": 309,
                "value": "0"
              },
              "odp0008": {
                "pairingID": 4,
                "value": "0"
              },
              "odp0009": {
                "pairingID": 37,
                "value": "0"
              },
              "odp000a": {
                "pairingID": 38,
                "value": "0"
              },
              "odp000b": {
                "pairingID": 39,
                "value": "0"
              },
              "odp000c": {
                "pairingID": 53,
                "value": "1"
              },
              "odp000d": {
                "pairingID": 6,
                "value": "0"
              }
            }
          },
}
```