### PR TITLE
add wireless thermostat accessory Heizkörperthermostat Basic 6256/1-WL

### DIFF
--- a/dist/accessories/BuschJaegerWirelessThermostatAccessory.d.ts
+++ b/dist/accessories/BuschJaegerWirelessThermostatAccessory.d.ts
@@ -1,0 +1,16 @@
+export = BuschJaegerWirelessThermostatAccessory;
+declare function BuschJaegerWirelessThermostatAccessory(platform: any, Service: any, Characteristic: any, actuator: any, channel?: null, mapping?: null, ...args: any[]): void;
+declare class BuschJaegerWirelessThermostatAccessory {
+    constructor(platform: any, Service: any, Characteristic: any, actuator: any, channel?: null, mapping?: null, ...args: any[]);
+    channel: string;
+    lastTargetTemperature: number;
+    getCurrentHeatingCoolingState: (callback: any) => void;
+    getTargetHeatingCoolingState: (callback: any) => void;
+    setTargetHeatingCoolingState: (value: any, callback: any) => void;
+    getCurrentTemperature: (callback: any) => void;
+    getTargetTemperature: (callback: any) => void;
+    setTargetTemperature: (value: any, callback: any) => void;
+    getTemperatureDisplayUnits: (callback: any) => void;
+    updateCharacteristics: () => void;
+    roundHalf: (value: any) => string;
+}

--- a/dist/accessories/BuschJaegerWirelessThermostatAccessory.js
+++ b/dist/accessories/BuschJaegerWirelessThermostatAccessory.js
@@ -1,0 +1,151 @@
+"use strict";
+
+var util = require("util");
+
+var BuschJaegerAccessory = require('./BuschJaegerAccessory.js').BuschJaegerAccessory;
+
+
+function BuschJaegerWirelessThermostatAccessory(platform, Service, Characteristic, actuator, channel = null, mapping = null) {
+    BuschJaegerWirelessThermostatAccessory.super_.apply(this, arguments);
+
+    this.channel = '0000';
+
+    var thermostatService = new Service.Thermostat();
+
+    thermostatService.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+        .on('get', this.getCurrentHeatingCoolingState.bind(this));
+
+    thermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState)
+        .setProps({
+            validValues: [0, 3]
+        })
+        .on('get', this.getTargetHeatingCoolingState.bind(this))
+        .on('set', this.setTargetHeatingCoolingState.bind(this));
+
+    thermostatService.getCharacteristic(Characteristic.CurrentTemperature)
+        .on('get', this.getCurrentTemperature.bind(this));
+
+    thermostatService.getCharacteristic(Characteristic.TargetTemperature)
+        .setProps({
+            maxValue: 35,
+            minValue: 7,
+            minStep: 0.5
+        })
+        .on('get', this.getTargetTemperature.bind(this))
+        .on('set', this.setTargetTemperature.bind(this));
+
+    thermostatService.getCharacteristic(Characteristic.TemperatureDisplayUnits)
+        .setProps({
+            validValues: [0]
+        })
+        .on('get', this.getTemperatureDisplayUnits.bind(this));
+
+    /*
+     * If we set TargetHeatingCoolingState to OFF the accessory will set the
+     * target heating temperature to 35°C or 7°C. We will store the last target temperature
+     * in this variable do prevent incorrect readouts. The real target temperature
+     * is re-set correctly when the TargetHeatingCoolingState is set back to AUTO.
+     */
+    this.lastTargetTemperature = 0;
+
+    this.services.thermostat = thermostatService;
+}
+
+BuschJaegerWirelessThermostatAccessory.prototype = {
+    getCurrentHeatingCoolingState: function(callback) {
+        if (callback) {
+            let mode = this.Characteristic.CurrentHeatingCoolingState.HEAT;
+
+            let valveOpen = parseInt(this.getValue(this.channel, 'odp0008'));
+
+            if (valveOpen == 0) {
+                mode = this.Characteristic.CurrentHeatingCoolingState.OFF;
+            }
+
+            callback(null, mode);
+        }
+    },
+    getTargetHeatingCoolingState: function(callback) {
+        if (callback) {
+            let mode = this.Characteristic.TargetHeatingCoolingState.OFF;
+            if (this.getValue(this.channel, 'odp0002') == '1') {
+                mode = this.Characteristic.TargetHeatingCoolingState.AUTO
+            }
+            callback(null, mode);
+        }
+    },
+    setTargetHeatingCoolingState: function(value, callback) {
+        if (value == this.Characteristic.TargetHeatingCoolingState.OFF) {
+            this.setValue(this.channel, 'idp0005', '0');
+        } else {
+            this.setValue(this.channel, 'idp0005', '1');
+        }
+
+        this.waitForUpdate(callback, this.channel, 'odp0002');
+    },
+    getCurrentTemperature: function(callback) {
+        if (callback) {
+            let temperature = this.roundHalf(this.getValue(this.channel, 'odp0007'));
+            callback(null, temperature);
+        }
+    },
+    getTargetTemperature: function(callback) {
+        this.getTargetHeatingCoolingState(function(joker, targetHeatingCoolingState) {
+            let targetTemperature = this.roundHalf(this.getValue(this.channel, 'odp0000'));
+
+            // See param this.lastTargetTemperature for more information
+            if (targetHeatingCoolingState != this.Characteristic.TargetHeatingCoolingState.OFF
+              || (targetTemperature != 7 && targetTemperature != 35) || this.lastTargetTemperature == 0) {
+                this.lastTargetTemperature = targetTemperature;
+            }
+
+            if (callback) {
+                callback(null, this.lastTargetTemperature);
+            }
+        }.bind(this));
+    },
+    setTargetTemperature: function(value, callback) {
+        this.getTargetHeatingCoolingState(function(joker, targetHeatingCoolingState) {
+            // We first need to enable the Thermostat before we can set a new Temperature.
+            if (targetHeatingCoolingState == this.Characteristic.TargetHeatingCoolingState.OFF) {
+                this.setTargetHeatingCoolingState(this.Characteristic.TargetHeatingCoolingState.AUTO, function() {
+                    this.setTargetTemperature(value, callback);
+                }.bind(this));
+            } else {
+                this.setValue(this.channel, 'idp0009', value);
+
+                this.waitForUpdate(callback, this.channel, 'odp0000');
+            }
+        }.bind(this));
+    },
+    getTemperatureDisplayUnits: function(callback) {
+        if (callback) {
+            callback(null, this.Characteristic.TemperatureDisplayUnits.CELSIUS);
+        }
+    },
+
+    updateCharacteristics: function() {
+        var that = this;
+
+        this.getCurrentHeatingCoolingState(function(joker, value) {
+            that.services.thermostat.getCharacteristic(that.Characteristic.CurrentHeatingCoolingState).updateValue(value);
+        });
+        this.getTargetHeatingCoolingState(function(joker, value) {
+            that.services.thermostat.getCharacteristic(that.Characteristic.TargetHeatingCoolingState).updateValue(value);
+            that.getTargetTemperature(function(joker, value) {
+                that.services.thermostat.getCharacteristic(that.Characteristic.TargetTemperature).updateValue(value);
+            });
+        });
+        this.getCurrentTemperature(function(joker, value) {
+            that.services.thermostat.getCharacteristic(that.Characteristic.CurrentTemperature).updateValue(value);
+        });
+    },
+
+    roundHalf: function(value) {
+        return (Math.round(value * 2) / 2).toFixed(1);
+    }
+}
+
+util.inherits(BuschJaegerWirelessThermostatAccessory, BuschJaegerAccessory);
+
+module.exports = BuschJaegerWirelessThermostatAccessory;

--- a/index.js
+++ b/index.js
@@ -186,6 +186,8 @@ BuschJaegerApPlatform.prototype.getAccessoryClass = function (deviceId, channel,
             return ['BuschJaegerMediaPlayerAccessory', null];
         case '7d':
             return ['BuschJaegerSmokeSensorAccessory', null];
+        case '3e':
+            return ['BuschJaegerWirelessThermostatAccessory', null];
 
         default:
             return [null, null];

--- a/src/accessories/BuschJaegerWirelessThermostatAccessory.js
+++ b/src/accessories/BuschJaegerWirelessThermostatAccessory.js
@@ -1,0 +1,151 @@
+"use strict";
+
+var util = require("util");
+
+var BuschJaegerAccessory = require('./BuschJaegerAccessory.js').BuschJaegerAccessory;
+
+
+function BuschJaegerWirelessThermostatAccessory(platform, Service, Characteristic, actuator, channel = null, mapping = null) {
+    BuschJaegerWirelessThermostatAccessory.super_.apply(this, arguments);
+
+    this.channel = '0000';
+
+    var thermostatService = new Service.Thermostat();
+
+    thermostatService.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+        .on('get', this.getCurrentHeatingCoolingState.bind(this));
+
+    thermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState)
+        .setProps({
+            validValues: [0, 3]
+        })
+        .on('get', this.getTargetHeatingCoolingState.bind(this))
+        .on('set', this.setTargetHeatingCoolingState.bind(this));
+
+    thermostatService.getCharacteristic(Characteristic.CurrentTemperature)
+        .on('get', this.getCurrentTemperature.bind(this));
+
+    thermostatService.getCharacteristic(Characteristic.TargetTemperature)
+        .setProps({
+            maxValue: 35,
+            minValue: 7,
+            minStep: 0.5
+        })
+        .on('get', this.getTargetTemperature.bind(this))
+        .on('set', this.setTargetTemperature.bind(this));
+
+    thermostatService.getCharacteristic(Characteristic.TemperatureDisplayUnits)
+        .setProps({
+            validValues: [0]
+        })
+        .on('get', this.getTemperatureDisplayUnits.bind(this));
+
+    /*
+     * If we set TargetHeatingCoolingState to OFF the accessory will set the
+     * target heating temperature to 35°C or 7°C. We will store the last target temperature
+     * in this variable do prevent incorrect readouts. The real target temperature
+     * is re-set correctly when the TargetHeatingCoolingState is set back to AUTO.
+     */
+    this.lastTargetTemperature = 0;
+
+    this.services.thermostat = thermostatService;
+}
+
+BuschJaegerWirelessThermostatAccessory.prototype = {
+    getCurrentHeatingCoolingState: function(callback) {
+        if (callback) {
+            let mode = this.Characteristic.CurrentHeatingCoolingState.HEAT;
+
+            let valveOpen = parseInt(this.getValue(this.channel, 'odp0008'));
+
+            if (valveOpen == 0) {
+                mode = this.Characteristic.CurrentHeatingCoolingState.OFF;
+            }
+
+            callback(null, mode);
+        }
+    },
+    getTargetHeatingCoolingState: function(callback) {
+        if (callback) {
+            let mode = this.Characteristic.TargetHeatingCoolingState.OFF;
+            if (this.getValue(this.channel, 'odp0002') == '1') {
+                mode = this.Characteristic.TargetHeatingCoolingState.AUTO
+            }
+            callback(null, mode);
+        }
+    },
+    setTargetHeatingCoolingState: function(value, callback) {
+        if (value == this.Characteristic.TargetHeatingCoolingState.OFF) {
+            this.setValue(this.channel, 'idp0005', '0');
+        } else {
+            this.setValue(this.channel, 'idp0005', '1');
+        }
+
+        this.waitForUpdate(callback, this.channel, 'odp0002');
+    },
+    getCurrentTemperature: function(callback) {
+        if (callback) {
+            let temperature = this.roundHalf(this.getValue(this.channel, 'odp0007'));
+            callback(null, temperature);
+        }
+    },
+    getTargetTemperature: function(callback) {
+        this.getTargetHeatingCoolingState(function(joker, targetHeatingCoolingState) {
+            let targetTemperature = this.roundHalf(this.getValue(this.channel, 'odp0000'));
+
+            // See param this.lastTargetTemperature for more information
+            if (targetHeatingCoolingState != this.Characteristic.TargetHeatingCoolingState.OFF
+              || (targetTemperature != 7 && targetTemperature != 35) || this.lastTargetTemperature == 0) {
+                this.lastTargetTemperature = targetTemperature;
+            }
+
+            if (callback) {
+                callback(null, this.lastTargetTemperature);
+            }
+        }.bind(this));
+    },
+    setTargetTemperature: function(value, callback) {
+        this.getTargetHeatingCoolingState(function(joker, targetHeatingCoolingState) {
+            // We first need to enable the Thermostat before we can set a new Temperature.
+            if (targetHeatingCoolingState == this.Characteristic.TargetHeatingCoolingState.OFF) {
+                this.setTargetHeatingCoolingState(this.Characteristic.TargetHeatingCoolingState.AUTO, function() {
+                    this.setTargetTemperature(value, callback);
+                }.bind(this));
+            } else {
+                this.setValue(this.channel, 'idp0009', value);
+
+                this.waitForUpdate(callback, this.channel, 'odp0000');
+            }
+        }.bind(this));
+    },
+    getTemperatureDisplayUnits: function(callback) {
+        if (callback) {
+            callback(null, this.Characteristic.TemperatureDisplayUnits.CELSIUS);
+        }
+    },
+
+    updateCharacteristics: function() {
+        var that = this;
+
+        this.getCurrentHeatingCoolingState(function(joker, value) {
+            that.services.thermostat.getCharacteristic(that.Characteristic.CurrentHeatingCoolingState).updateValue(value);
+        });
+        this.getTargetHeatingCoolingState(function(joker, value) {
+            that.services.thermostat.getCharacteristic(that.Characteristic.TargetHeatingCoolingState).updateValue(value);
+            that.getTargetTemperature(function(joker, value) {
+                that.services.thermostat.getCharacteristic(that.Characteristic.TargetTemperature).updateValue(value);
+            });
+        });
+        this.getCurrentTemperature(function(joker, value) {
+            that.services.thermostat.getCharacteristic(that.Characteristic.CurrentTemperature).updateValue(value);
+        });
+    },
+
+    roundHalf: function(value) {
+        return (Math.round(value * 2) / 2).toFixed(1);
+    }
+}
+
+util.inherits(BuschJaegerWirelessThermostatAccessory, BuschJaegerAccessory);
+
+module.exports = BuschJaegerWirelessThermostatAccessory;


### PR DESCRIPTION
# Description
This pull request adds support for radio heating thermostats of type "Heizkörperthermostat Basic 6256/1-WL“. Possibly also for the „Heizkörperthermostat Comfort 6256/2-WL“, but unfortunately I do not have this one for testing. The wireless thermostats use different datapoints than the existing thermostat implementation, so I added a new accessory category, took the existing implementation and adjusted the datapoints.

# API sample
```
{
  "00000000-0000-0000-0000-000000000000": {
    "devices": {
      "XXXXXXXXXX": {
        "floor": "02",
        "room": "09",
        "interface": "RF",
        "displayName": "Thermostat Büro",
        "unresponsive": false,
        "channels": {
          "ch0000": {
            "displayName": "Thermostat Büro",
            "functionID": "3e",
            "inputs": {
              "idp0000": {
                "pairingID": 52,
                "value": "invalid"
              },
              "idp0001": {
                "pairingID": 56,
                "value": "0"
              },
              "idp0002": {
                "pairingID": 54,
                "value": "0"
              },
              "idp0003": {
                "pairingID": 57,
                "value": "invalid"
              },
              "idp0004": {
                "pairingID": 58,
                "value": "0"
              },
              "idp0005": {
                "pairingID": 66,
                "value": "0"
              },
              "idp0006": {
                "pairingID": 7,
                "value": "0"
              },
              "idp0007": {
                "pairingID": 4,
                "value": "0"
              },
              "idp0008": {
                "pairingID": 53,
                "value": "0"
              },
              "idp0009": {
                "pairingID": 320,
                "value": "21"
              },
              "idp000a": {
                "pairingID": 304,
                "value": "invalid"
              },
              "idp000b": {
                "pairingID": 332,
                "value": "0"
              }
            },
            "outputs": {
              "odp0000": {
                "pairingID": 51,
                "value": "7"
              },
              "odp0001": {
                "pairingID": 52,
                "value": "0"
              },
              "odp0002": {
                "pairingID": 56,
                "value": "0"
              },
              "odp0003": {
                "pairingID": 54,
                "value": "96"
              },
              "odp0004": {
                "pairingID": 57,
                "value": "invalid"
              },
              "odp0005": {
                "pairingID": 66,
                "value": "0"
              },
              "odp0006": {
                "pairingID": 58,
                "value": "0"
              },
              "odp0007": {
                "pairingID": 304,
                "value": "22.8"
              },
              "odp0008": {
                "pairingID": 331,
                "value": "0"
              },
              "odp0009": {
                "pairingID": 333,
                "value": "0"
              },
              "odp000a": {
                "pairingID": 305,
                "value": "0"
              },
              "odp000b": {
                "pairingID": 273,
                "value": "0"
              },
              "odp000c": {
                "pairingID": 59,
                "value": "21"
              },
              "odp000d": {
                "pairingID": 68,
                "value": "0"
              }
            }
          }
        }
      }
    }
  }
}
```